### PR TITLE
Preventing duplicate Slatwall tabs in 6.1

### DIFF
--- a/eventHandler.cfc
+++ b/eventHandler.cfc
@@ -145,7 +145,9 @@ Notes:
 	</cffunction>
 	
 	<cffunction name="onContentEdit" access="public" returntype="any">
-		<cfset getSlatwallEventHandler().onContentEdit( argumentcollection=arguments ) />
+		<cfif getBean('configBean').getVersion() lt 6.1> 
+			<cfset getSlatwallEventHandler().onContentEdit( argumentcollection=arguments ) />
+		</cfif>
 	</cffunction>
 	
 	<cffunction name="getSlatwallEventHandler" returntype="any">


### PR DESCRIPTION
Mura now supports implicit event binding for admin rendering events. This prevents the slatwall tab from rendering twice.
